### PR TITLE
Magic pond always yields fish (fixes double-junk bonus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Magicpond
 A quick side project to encourage players to fish in one place on the server.
-Players receive bonus fish for fishing in a designated magic pond.
+A magic pond always yields fish (vanilla junk/treasure are converted to fish) plus
+a bonus fish per catch — unless the spot is overfished, in which case it yields
+junk like anywhere else until it recovers.
 
 Magic ponds are designated per-chunk in-game: stand in the chunk and run
 `/magicpond set` (`/magicpond unset` to remove, `/magicpond list` to review).

--- a/src/main/java/com/playtheatria/jliii/magicpond/listeners/PlayerFish.java
+++ b/src/main/java/com/playtheatria/jliii/magicpond/listeners/PlayerFish.java
@@ -44,6 +44,11 @@ public class PlayerFish implements Listener {
 
         World world = event.getPlayer().getWorld();
         Item caughtItem = (Item) event.getCaught();
+        // A magic pond always yields fish — if vanilla rolled junk/treasure, swap it for one.
+        // (Depleted ponds are handled earlier: they keep the overfishing junk and skip the bonus.)
+        if (!isFish(caughtItem.getItemStack().getType())) {
+            caughtItem.setItemStack(new ItemStack(randomFish()));
+        }
         new BukkitRunnable() {
             public void run() {
                 if (dropTropical()) {
@@ -72,5 +77,20 @@ public class PlayerFish implements Listener {
     private int range() {
         int range = (10) + 1;
         return (int) (Math.random() * range);
+    }
+
+    private boolean isFish(Material material) {
+        return material == Material.COD
+                || material == Material.SALMON
+                || material == Material.TROPICAL_FISH
+                || material == Material.PUFFERFISH;
+    }
+
+    private Material randomFish() {
+        double roll = Math.random();
+        if (roll < 0.60) return Material.COD;
+        if (roll < 0.90) return Material.SALMON;
+        if (roll < 0.98) return Material.PUFFERFISH;
+        return Material.TROPICAL_FISH;
     }
 }


### PR DESCRIPTION
Vanilla fishing rolls junk ~10% of the time; the pond bonus copied whatever was caught, so junk catches produced double junk. Now a non-depleted pond converts any non-fish catch (junk or treasure) into a fish before the bonus is copied, so the catch and its bonus are both fish. Depleted spots are unchanged: they keep the overfishing junk and skip the bonus (single junk drop).


Claude-Session: https://claude.ai/code/session_01YCbgus4gwFvzeRxeaDfPzo