### PR TITLE
Lob the bonus fish to the player instead of overshooting

### DIFF
--- a/src/main/java/com/playtheatria/jliii/magicpond/listeners/PlayerFish.java
+++ b/src/main/java/com/playtheatria/jliii/magicpond/listeners/PlayerFish.java
@@ -9,12 +9,14 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.*;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
 
 public class PlayerFish implements Listener {
 
@@ -43,29 +45,31 @@ public class PlayerFish implements Listener {
         }
 
         World world = event.getPlayer().getWorld();
+        Player player = event.getPlayer();
         Item caughtItem = (Item) event.getCaught();
         // A magic pond always yields fish — if vanilla rolled junk/treasure, swap it for one.
         // (Depleted ponds are handled earlier: they keep the overfishing junk and skip the bonus.)
         if (!isFish(caughtItem.getItemStack().getType())) {
             caughtItem.setItemStack(new ItemStack(randomFish()));
         }
+        caughtItem.setGlowing(true);
+
+        // Lob the bonus fish from the catch spot to the player on a vanilla-style arc,
+        // rather than copying the caught item's velocity (which could overshoot past them).
+        Location catchLoc = caughtItem.getLocation().clone();
+        ItemStack bonusStack = caughtItem.getItemStack().clone();
         new BukkitRunnable() {
             public void run() {
                 if (dropTropical()) {
-                    Item item = world.dropItem(caughtItem.getLocation(), new ItemStack(Material.TROPICAL_FISH));
-                    item.setGlowing(true);
-                    item.setVelocity(caughtItem.getVelocity());
-                    event.getPlayer().sendActionBar(
+                    lobToPlayer(world, catchLoc, new ItemStack(Material.TROPICAL_FISH), player);
+                    player.sendActionBar(
                             Component.text("The Oracle blesses you with a tropical fish!")
                                     .color(NamedTextColor.YELLOW)
                                     .decorate(TextDecoration.ITALIC)
                     );
                 }
-                Item item = world.dropItem(caughtItem.getLocation(), new ItemStack(caughtItem.getItemStack()));
-                item.setVelocity(caughtItem.getVelocity());
-                item.setGlowing(true);
-                world.spawnParticle(Particle.HAPPY_VILLAGER, event.getHook().getLocation().add(0, 1.5, 0), 5);
-                event.getCaught().setGlowing(true);
+                lobToPlayer(world, catchLoc, bonusStack, player);
+                world.spawnParticle(Particle.HAPPY_VILLAGER, catchLoc.clone().add(0, 1.5, 0), 5);
             }
         }.runTaskLater(magicpond, 5);
     }
@@ -92,5 +96,20 @@ public class PlayerFish implements Listener {
         if (roll < 0.90) return Material.SALMON;
         if (roll < 0.98) return Material.PUFFERFISH;
         return Material.TROPICAL_FISH;
+    }
+
+    /**
+     * Drops a glowing item at {@code from} and lobs it toward the player using the same arc
+     * vanilla uses to reel a catch in, so it lands on the player instead of flying past.
+     */
+    private void lobToPlayer(World world, Location from, ItemStack stack, Player player) {
+        Item item = world.dropItem(from, stack);
+        item.setGlowing(true);
+        Location to = player.getLocation();
+        double dx = to.getX() - from.getX();
+        double dy = to.getY() - from.getY();
+        double dz = to.getZ() - from.getZ();
+        double lob = Math.sqrt(Math.sqrt(dx * dx + dy * dy + dz * dz)) * 0.08;
+        item.setVelocity(new Vector(dx * 0.1, dy * 0.1 + lob, dz * 0.1));
     }
 }


### PR DESCRIPTION
The bonus drop copied the caught item's velocity from inside a delayed task, but by then the fish was mid reel-in, so the bonus often sailed past the player. Now the bonus is dropped at the catch spot and given a velocity aimed at the player using vanilla's reel-in arc (dx*0.1, dy*0.1 + dist^0.25 * 0.08, dz*0.1), so it lands on them. Catch spot and stack are captured up front rather than re-read from the (possibly gone) caught entity.


Claude-Session: https://claude.ai/code/session_01YCbgus4gwFvzeRxeaDfPzo