### PR TITLE
Fix stale docs/comments after the junk-drop and self-rescheduling cha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Magic ponds are designated per-chunk in-game: stand in the chunk and run
 Designations persist in `ponds.yml` in the plugin's data folder.
 
 It also includes an **overfishing** system that deters autofishing: a player who
-fishes one spot too frequently for too long stops catching fish there until the
-spot recovers. See [docs/overfishing.md](docs/overfishing.md) for the model,
-configuration, and in-game verification steps.
+fishes one spot too frequently for too long starts pulling junk instead of fish
+there until the spot recovers. See [docs/overfishing.md](docs/overfishing.md) for
+the model, configuration, and in-game verification steps.
 
 ### Dependencies
 - None at runtime. Built against the Paper API (`paper.version` in `pom.xml`).

--- a/docs/overfishing.md
+++ b/docs/overfishing.md
@@ -6,10 +6,10 @@ there until the spot recovers.
 
 This is what lets the **magic pond run without mcMMO**. Previously the pond
 bonus was gated by mcMMO's `isExploitingFishing` check; now it's gated by this
-system instead. It applies everywhere (the pond is not exempt): a depleted catch
-is cancelled, and because the bonus listener runs later with
-`ignoreCancelled = true`, depletion suppresses the vanilla fish *and* the pond
-bonus together.
+system instead. Overfishing applies everywhere (the pond included): a depleted
+catch yields junk instead of fish (or is cancelled if no junk is configured), and
+the pond's bonus listener skips its bonus on a depleted spot — so an overfished
+pond gives neither the fish nor the bonus.
 
 ## Why not just use mcMMO's check?
 
@@ -59,7 +59,7 @@ outcome. Steady fishing settles at an equilibrium of
 
 - **Sustained one-spot fishing** climbs past the cap in ~`pressure-cap / gain`
   catches (~5 by default) and stays depleted while you keep casting there, because
-  denied catches still add pressure — so you must aim somewhere new.
+  every catch adds pressure even once depleted — so you must aim somewhere new.
 - **If you fish slower than the spot recovers**, the equilibrium stays under the
   cap and the spot never depletes. This is the key tuning relationship: a **lower
   `pressure-cap`** (or longer half-life) makes the mechanic trigger sooner *and*
@@ -124,7 +124,7 @@ movement-based idea below.
 - `/magicpond info` — current settings + tracked-player count.
 - `/magicpond check` — pressure of the cell you're standing in.
 - `/magicpond clear` — wipe all tracked pressure.
-- `/magicpond reload` — reload `config.yml` (and reschedule the sweep).
+- `/magicpond reload` — reload `config.yml` through the ConfigManager.
 - `magicpond.admin` (op) — use the command.
 - `magicpond.use` (op) — receive the magic-pond bonus. Overfishing applies to everyone regardless of this permission.
 

--- a/src/main/java/com/playtheatria/jliii/magicpond/tracking/FishingSpot.java
+++ b/src/main/java/com/playtheatria/jliii/magicpond/tracking/FishingSpot.java
@@ -3,7 +3,7 @@ package com.playtheatria.jliii.magicpond.tracking;
 /**
  * The mutable state of a single fishing cell for a single player: how much "pressure"
  * (recent fishing activity) it carries, when it was last touched, and whether it is
- * currently depleted (catches denied).
+ * currently depleted (fished out).
  * <p>
  * Pressure decays exponentially toward zero so that a spot recovers if left alone.
  */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@
 # The overfishing system tracks where each player's hook lands on a grid of
 # cells. Every catch adds "pressure" to that cell; pressure decays over time.
 # Fish a spot too fast for too long and its pressure passes the cap, after
-# which catches there are denied (no fish) until it recovers.
+# which catches there yield junk instead of fish until it recovers.
 #
 # This replaces mcMMO's single-slot "last cast" anti-exploit, which is bypassed
 # by simply alternating between two fishing spots. Here every cell is tracked
@@ -44,7 +44,7 @@ overfishing:
   # set equal to pressure-cap to disable the warning.
   warn-threshold: 3.0
 
-  # Pressure added per fish caught (applied even to denied catches, so an
+  # Pressure added per fish caught (applied even on depleted catches, so an
   # autofisher hammering a depleted spot keeps it depleted).
   gain-per-catch: 1.0
 
@@ -74,5 +74,6 @@ overfishing:
   notify-player: true
 
   # How often (seconds) the background sweep decays and evicts recovered cells
-  # to keep memory bounded. Changing this reschedules the task on reload.
+  # to keep memory bounded. The sweep re-reads this each cycle, so a change takes
+  # effect on the next cycle after /magicpond reload.
   sweep-interval-seconds: 120


### PR DESCRIPTION
…nges

Audit of all doc surfaces (javadocs, docs/overfishing.md, README, config.yml). The Java javadocs were accurate; corrected the spots describing superseded behavior:
- overfishing.md intro: depleted catches yield junk (or cancel) and the pond bonus is skipped via the isDepleted check, not "cancelled via ignoreCancelled".
- overfishing.md/config.yml: "denied (no fish)" wording -> "junk instead of fish".
- /magicpond reload no longer "reschedules the sweep" (the sweep self-reschedules and re-reads the interval each cycle); updated the reload line and the sweep-interval-seconds comment.
- README: overfishing now yields junk rather than "stops catching fish".
- FishingSpot javadoc: "(catches denied)" -> "(fished out)".


Claude-Session: https://claude.ai/code/session_01YCbgus4gwFvzeRxeaDfPzo